### PR TITLE
Replaced `python_json_config` with own code

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -49,9 +49,13 @@ account_client = boto3.client('account', config=client_config)
 account = Account(logger=logger, account_client=account_client)
 
 utils = Utils(logger=logger)
+
 config_handler = ConfigHandler(logger=logger)
 config = config_handler.get_combined_config()
-jira = JiraHandler(logger=logger, config=config)
+logger.debug("Final combined config - " + str(config))
+
+if config["jira"]["enabled"]:
+    jira = JiraHandler(logger=logger, config=config)
 
 # post_http_request: Send a HTTP POST request to the `api_endpoint_url`, returns the HTTP response as dict.
 def post_http_request(event: dict, context: dict, api_endpoint_url: str, http_body: str) -> dict:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-boto3==1.33.12
-botocore==1.33.12
-cfnresponse==1.1.5
-jira==3.8.0
-mergedeep==1.3.4
-python_json_config==1.2.3
-urllib3<=2.1.0
+boto3~=1.33.12
+botocore~=1.33.12
+cfnresponse~=1.1.5
+jira~=3.8.0
+mergedeep~=1.3.4
+python_json_config~=1.2.3
+urllib3~=2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-boto3~=1.33.12
-botocore~=1.33.12
-cfnresponse~=1.1.5
-jira~=3.8.0
-mergedeep~=1.3.4
-python_json_config~=1.2.3
-urllib3~=2.1.0
+boto3==1.33.12
+botocore==1.33.12
+cfnresponse==1.1.5
+flatten_json==0.1.14
+jira==3.8.0
+mergedeep==1.3.4
+urllib3<2.1


### PR DESCRIPTION
`python_json_config` had a dependency with `json_schema` which had an issue with `rpds` throwing an error ```"Unable to import module 'handler': No module named 'rpds.rpds'"```
- Replaced `python_json_config` with `json` implementation and `flatten_json` required field validation.